### PR TITLE
Add file tree panel with material icons

### DIFF
--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -26,7 +26,11 @@
 	"linter": {
 		"enabled": true,
 		"rules": {
-			"recommended": true
+			"recommended": true,
+			"a11y": {
+				"useKeyWithClickEvents": "off",
+				"noStaticElementInteractions": "off"
+			}
 		}
 	},
 	"javascript": {

--- a/frontend/tauri-app/package-lock.json
+++ b/frontend/tauri-app/package-lock.json
@@ -19,6 +19,7 @@
 				"@xterm/addon-web-links": "^0.11.0",
 				"@xterm/xterm": "^5.5.0",
 				"framer-motion": "^12.18.1",
+				"material-file-icons": "^2.4.0",
 				"motion": "^12.19.1",
 				"react": "^19.1.0",
 				"react-dom": "^19.1.0",
@@ -2176,6 +2177,12 @@
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
+		},
+		"node_modules/material-file-icons": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/material-file-icons/-/material-file-icons-2.4.0.tgz",
+			"integrity": "sha512-MgxhwBgoiNXyQdZVtXvdqP8t7Fu/Z3zW1aPeYN+UqtepzbKyf41b+Wme6DnwGk5Crt2JzmWLtl1XGE2YMooaQw==",
+			"license": "MIT"
 		},
 		"node_modules/minipass": {
 			"version": "7.1.2",

--- a/frontend/tauri-app/package.json
+++ b/frontend/tauri-app/package.json
@@ -28,6 +28,7 @@
 		"@xterm/addon-web-links": "^0.11.0",
 		"@xterm/xterm": "^5.5.0",
 		"framer-motion": "^12.18.1",
+		"material-file-icons": "^2.4.0",
 		"motion": "^12.19.1",
 		"react": "^19.1.0",
 		"react-dom": "^19.1.0",

--- a/frontend/tauri-app/src-tauri/Cargo.toml
+++ b/frontend/tauri-app/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ vt100          = "0.15"
 unicode-width  = "0.1"
 tauri-plugin-store = "2"
 tauri-plugin-fs = "2"
+walkdir = "2.5.0"
 
 [features]
 # this feature is used for production builds or when `devPath` points to the filesystem

--- a/frontend/tauri-app/src-tauri/src/file_tree.rs
+++ b/frontend/tauri-app/src-tauri/src/file_tree.rs
@@ -1,0 +1,67 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use walkdir::{DirEntry, WalkDir};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileNode {
+	pub name: String,
+	pub path: String,
+	pub is_directory: bool,
+	pub children: Option<Vec<FileNode>>,
+	pub extension: Option<String>,
+}
+
+fn is_hidden(entry: &DirEntry) -> bool {
+	entry
+		.file_name()
+		.to_str()
+		.map(|s| s.starts_with('.'))
+		.unwrap_or(false)
+}
+
+pub async fn read_directory(path: &str) -> Result<Vec<FileNode>> {
+	let path = Path::new(path);
+	let mut nodes = Vec::new();
+
+	for entry in WalkDir::new(path)
+		.min_depth(1)
+		.max_depth(1)
+		.into_iter()
+		.filter_entry(|e| !is_hidden(e))
+		.filter_map(|e| e.ok())
+	{
+		let metadata = entry.metadata()?;
+		let file_name = entry.file_name().to_string_lossy().to_string();
+		let file_path = entry.path();
+		let path_str = file_path.to_string_lossy().to_string();
+
+		let extension = if metadata.is_file() {
+			file_path
+				.extension()
+				.and_then(|ext| ext.to_str())
+				.map(|s| s.to_string())
+		} else {
+			None
+		};
+
+		let node = FileNode {
+			name: file_name,
+			path: path_str,
+			is_directory: metadata.is_dir(),
+			children: None,
+			extension,
+		};
+
+		nodes.push(node);
+	}
+
+	nodes.sort_by(|a, b| match (a.is_directory, b.is_directory) {
+		(true, false) => std::cmp::Ordering::Less,
+		(false, true) => std::cmp::Ordering::Greater,
+		_ => a.name.to_lowercase().cmp(&b.name.to_lowercase()),
+	});
+
+	Ok(nodes)
+}

--- a/frontend/tauri-app/src-tauri/src/lib.rs
+++ b/frontend/tauri-app/src-tauri/src/lib.rs
@@ -1,125 +1,136 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(
-    all(not(debug_assertions), target_os = "windows"),
-    windows_subsystem = "windows"
+	all(not(debug_assertions), target_os = "windows"),
+	windows_subsystem = "windows"
 )]
 
 use std::sync::Arc;
 use tauri::State;
 
 mod terminal;
-use terminal::{TerminalManager, TerminalConfig};
+use terminal::{TerminalConfig, TerminalManager};
 
 mod custom_terminal;
 mod custom_terminal_commands;
 use custom_terminal_commands::{
-    AppState,
-    custom_connect_terminal,
-    custom_reconnect_terminal,
-    custom_kill_terminal,
-    custom_send_input_lines,
-    custom_send_raw_input,
-    custom_send_ctrl_c,
-    custom_send_ctrl_d,
-    custom_send_scroll_up,
-    custom_send_scroll_down,
-    custom_resize_terminal,
+	custom_connect_terminal, custom_kill_terminal, custom_reconnect_terminal,
+	custom_resize_terminal, custom_send_ctrl_c, custom_send_ctrl_d,
+	custom_send_input_lines, custom_send_raw_input, custom_send_scroll_down,
+	custom_send_scroll_up, AppState,
 };
+
+mod file_tree;
+use file_tree::{read_directory, FileNode};
 
 #[tauri::command]
 async fn create_terminal_connection(
-    config: TerminalConfig,
-    terminal_manager: State<'_, Arc<TerminalManager>>,
-    app_handle: tauri::AppHandle,
+	config: TerminalConfig,
+	terminal_manager: State<'_, Arc<TerminalManager>>,
+	app_handle: tauri::AppHandle,
 ) -> Result<String, String> {
-    terminal_manager
-        .create_connection(config, app_handle)
-        .map_err(|e| e.to_string())
+	terminal_manager
+		.create_connection(config, app_handle)
+		.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 async fn send_terminal_data(
-    connection_id: String,
-    data: String,
-    terminal_manager: State<'_, Arc<TerminalManager>>,
+	connection_id: String,
+	data: String,
+	terminal_manager: State<'_, Arc<TerminalManager>>,
 ) -> Result<(), String> {
-    terminal_manager
-        .send_data(&connection_id, &data)
-        .map_err(|e| e.to_string())
+	terminal_manager
+		.send_data(&connection_id, &data)
+		.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 async fn resize_terminal(
-    connection_id: String,
-    cols: u16,
-    rows: u16,
-    terminal_manager: State<'_, Arc<TerminalManager>>,
+	connection_id: String,
+	cols: u16,
+	rows: u16,
+	terminal_manager: State<'_, Arc<TerminalManager>>,
 ) -> Result<(), String> {
-    terminal_manager
-        .resize_terminal(&connection_id, cols, rows)
-        .map_err(|e| e.to_string())
+	terminal_manager
+		.resize_terminal(&connection_id, cols, rows)
+		.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 async fn close_terminal_connection(
-    connection_id: String,
-    terminal_manager: State<'_, Arc<TerminalManager>>,
+	connection_id: String,
+	terminal_manager: State<'_, Arc<TerminalManager>>,
 ) -> Result<(), String> {
-    terminal_manager
-        .close_connection(&connection_id)
-        .map_err(|e| e.to_string())
+	terminal_manager
+		.close_connection(&connection_id)
+		.map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 async fn get_available_terminal_types() -> Vec<String> {
-    TerminalManager::get_available_terminal_types()
+	TerminalManager::get_available_terminal_types()
 }
 
 #[tauri::command]
 async fn validate_terminal_config(config: TerminalConfig) -> bool {
-    TerminalManager::validate_config(&config)
+	TerminalManager::validate_config(&config)
 }
 
 #[tauri::command]
 async fn cleanup_dead_connections(
-    terminal_manager: State<'_, Arc<TerminalManager>>,
+	terminal_manager: State<'_, Arc<TerminalManager>>,
 ) -> Result<(), String> {
-    terminal_manager
-        .cleanup_dead_connections()
-        .map_err(|e| e.to_string())
+	terminal_manager
+		.cleanup_dead_connections()
+		.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn get_current_dir() -> Result<String, String> {
+	std::env::current_dir()
+		.map(|p| p.to_string_lossy().to_string())
+		.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn get_file_tree(path: String) -> Result<Vec<FileNode>, String> {
+	read_directory(&path).await.map_err(|e| e.to_string())
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    let terminal_manager = Arc::new(TerminalManager::new());
-    let custom_terminal_state = AppState::new();
+	let terminal_manager = Arc::new(TerminalManager::new());
+	let custom_terminal_state = AppState::new();
 
-    tauri::Builder::default()
-        .plugin(tauri_plugin_store::Builder::new().build())
-        .plugin(tauri_plugin_fs::init())
-        .manage(terminal_manager)
-        .manage(custom_terminal_state)
-        .invoke_handler(tauri::generate_handler![
-            // Original terminal commands
-            create_terminal_connection,
-            send_terminal_data,
-            resize_terminal,
-            close_terminal_connection,
-            get_available_terminal_types,
-            validate_terminal_config,
-            cleanup_dead_connections,
-            // New custom terminal commands
-            custom_connect_terminal,
-            custom_reconnect_terminal,
-            custom_kill_terminal,
-            custom_send_input_lines,
-            custom_send_raw_input,
-            custom_send_ctrl_c,
-            custom_send_ctrl_d,
-            custom_send_scroll_up,
-            custom_send_scroll_down,
-            custom_resize_terminal
-        ])
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+	tauri::Builder::default()
+		.plugin(tauri_plugin_store::Builder::new().build())
+		.plugin(tauri_plugin_fs::init())
+		.manage(terminal_manager)
+		.manage(custom_terminal_state)
+		.invoke_handler(tauri::generate_handler![
+			// Original terminal commands
+			create_terminal_connection,
+			send_terminal_data,
+			resize_terminal,
+			close_terminal_connection,
+			get_available_terminal_types,
+			validate_terminal_config,
+			cleanup_dead_connections,
+			// New custom terminal commands
+			custom_connect_terminal,
+			custom_reconnect_terminal,
+			custom_kill_terminal,
+			custom_send_input_lines,
+			custom_send_raw_input,
+			custom_send_ctrl_c,
+			custom_send_ctrl_d,
+			custom_send_scroll_up,
+			custom_send_scroll_down,
+			custom_resize_terminal,
+			// File tree commands
+			get_current_dir,
+			get_file_tree
+		])
+		.run(tauri::generate_context!())
+		.expect("error while running tauri application");
 }

--- a/frontend/tauri-app/src/App.tsx
+++ b/frontend/tauri-app/src/App.tsx
@@ -5,6 +5,7 @@ import { getCurrentWebviewWindow } from "@tauri-apps/api/webviewWindow";
 import React, { useEffect, useState } from "react";
 import CanvasView from "./CanvasView";
 import { FileTreeCanvas } from "./canvas/FileTreeCanvas";
+import { Terminal } from "./canvas/Terminal";
 import type { CanvasElement } from "./canvas/types";
 import { useUserConfig } from "./hooks/useUserConfig";
 import Onboarding from "./Onboarding";
@@ -100,6 +101,11 @@ function App() {
 		}
 	};
 
+	const openNewTerminal = () => {
+		const terminalElement = Terminal.createLocalShell();
+		addElementRef.current?.(terminalElement);
+	};
+
 	if (loading) {
 		return (
 			<div
@@ -130,11 +136,9 @@ function App() {
 					)}
 				>
 					{/* Custom Titlebar */}
-					{/** biome-ignore lint/a11y/noStaticElementInteractions: <explanation> */}
 					<div
 						onMouseEnter={() => setShowTitlebar(true)}
 						onMouseLeave={() => setShowTitlebar(false)}
-						// onClick={() => setShowTitlebar(true)}
 						className={cn(
 							"h-10 flex items-center justify-center px-4 select-none relative z-50",
 						)}
@@ -158,6 +162,15 @@ function App() {
 										)}
 									>
 										📁
+									</button>
+									<button
+										type="button"
+										onClick={openNewTerminal}
+										className={cn(
+											"starting:opacity-0 opacity-90 px-2 py-1 text-xs bg-[var(--bg-600)] hover:bg-[var(--bg-700)] rounded transition-colors cursor-pointer mr-2",
+										)}
+									>
+										💻
 									</button>
 									<button
 										type="button"

--- a/frontend/tauri-app/src/CanvasView.tsx
+++ b/frontend/tauri-app/src/CanvasView.tsx
@@ -1,63 +1,82 @@
 import React, { useState } from "react";
 import Canvas from "./canvas/Canvas";
+import { CustomTerminal } from "./canvas/CustomTerminal";
 import { Rectangle } from "./canvas/Rectangle";
 import { Terminal } from "./canvas/Terminal";
-import { CustomTerminal } from "./canvas/CustomTerminal";
-import { CanvasElement, SizeTarget, AreaTarget } from "./canvas/types";
+import type { CanvasElement } from "./canvas/types";
 import { cn } from "./utils";
+
+interface CanvasViewProps {
+	onAddElementRef?: React.MutableRefObject<
+		((element: CanvasElement) => void) | null
+	>;
+}
 
 // Demo elements for testing
 const createDemoElements = (): CanvasElement[] => {
-	const isMac = navigator.platform.includes("Mac");
 	const isWindows = navigator.platform.includes("Win");
-	const isLinux = navigator.platform.includes("Linux");
+	const _isMac = navigator.platform.includes("Mac");
+	const _isLinux = navigator.platform.includes("Linux");
 
-	return isWindows ? [
-		// Rectangle.canvasElement(
-		// 	{ size: "large", aspectRatio: 1 / 1, area: "center" },
-		// 	1,
-		// ),
-		// CustomTerminal.canvasElement(
-		// 	{
-		// 		kind: {
-		// 			$type: "git-bash",
-		// 		},
-		// 		workingDir: "$HOME",
-		// 		lines: 5,
-		// 		cols: 10,
-		// 	},
-		// 	1,
-		// ),
-		CustomTerminal.canvasElement(
-			{
-				kind: {
-					$type: "wsl",
-					distribution: "Ubuntu",
-					workingDirectory: "~",
-				},
-				lines: 5,
-				cols: 10,
-			},
-			1,
-		),
-	] : [
-		Rectangle.canvasElement(
-			{ size: "large", aspectRatio: 1 / 1, area: "center" },
-			1,
-		),
-		Terminal.createLocalShell(),
-	]
+	return isWindows
+		? [
+				// Rectangle.canvasElement(
+				// 	{ size: "large", aspectRatio: 1 / 1, area: "center" },
+				// 	1,
+				// ),
+				// CustomTerminal.canvasElement(
+				// 	{
+				// 		kind: {
+				// 			$type: "git-bash",
+				// 		},
+				// 		workingDir: "$HOME",
+				// 		lines: 5,
+				// 		cols: 10,
+				// 	},
+				// 	1,
+				// ),
+				CustomTerminal.canvasElement(
+					{
+						kind: {
+							$type: "wsl",
+							distribution: "Ubuntu",
+							workingDirectory: "~",
+						},
+						lines: 5,
+						cols: 10,
+					},
+					1,
+				),
+			]
+		: [
+				Rectangle.canvasElement(
+					{ size: "large", aspectRatio: 1 / 1, area: "center" },
+					1,
+				),
+				Terminal.createLocalShell(),
+			];
 };
 
-const CanvasView: React.FC = () => {
+const CanvasView: React.FC<CanvasViewProps> = ({ onAddElementRef }) => {
 	const [elements, setElements] = useState<CanvasElement[]>(() =>
 		createDemoElements(),
 	);
-	const [stabilityWeight, setStabilityWeight] = useState(0.3);
+	const [stabilityWeight, _setStabilityWeight] = useState(0.3);
 
 	const handleElementsChange = (newElements: CanvasElement[]) => {
 		setElements(newElements);
 	};
+
+	const addElement = (element: CanvasElement) => {
+		setElements((prev) => [...prev, element]);
+	};
+
+	// Expose addElement function to parent
+	React.useEffect(() => {
+		if (onAddElementRef) {
+			onAddElementRef.current = addElement;
+		}
+	}, [onAddElementRef]);
 
 	return (
 		<div

--- a/frontend/tauri-app/src/canvas/Canvas.tsx
+++ b/frontend/tauri-app/src/canvas/Canvas.tsx
@@ -1,15 +1,20 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
-import { PanInfo } from "framer-motion";
-import { CanvasElement, ElementLayout, ElementTargets } from "./types";
-import { createGridWorker, WorkerMessage, WorkerResponse } from "./gridWorker";
-import { Rectangle } from "./Rectangle";
-import { Terminal, TerminalConfig } from "./Terminal";
-import RectangleOnCanvas from "./RectangleOnCanvas";
-import TerminalOnCanvas from "./TerminalOnCanvas";
-import CustomTerminalOnCanvas from "./CustomTerminalOnCanvas";
-import FileTreeOnCanvas from "./FileTreeOnCanvas";
-import { FileTreeCanvas } from "./FileTreeCanvas";
+import type { PanInfo } from "framer-motion";
+import type React from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { cn } from "../utils";
+import CustomTerminalOnCanvas from "./CustomTerminalOnCanvas";
+import type { FileTreeCanvas } from "./FileTreeCanvas";
+import FileTreeOnCanvas from "./FileTreeOnCanvas";
+import {
+	createGridWorker,
+	type WorkerMessage,
+	type WorkerResponse,
+} from "./gridWorker";
+import type { Rectangle } from "./Rectangle";
+import RectangleOnCanvas from "./RectangleOnCanvas";
+import type { Terminal, TerminalConfig } from "./Terminal";
+import TerminalOnCanvas from "./TerminalOnCanvas";
+import type { CanvasElement, ElementLayout, ElementTargets } from "./types";
 
 interface CanvasProps {
 	elements: CanvasElement[];
@@ -29,7 +34,7 @@ const simpleHash = (str: string): number => {
 };
 
 // Generate a stable color based on element ID
-const getColorForId = (id: string): string => {
+const _getColorForId = (id: string): string => {
 	const hash = simpleHash(id);
 	const hue = (hash % 120) + 180; // Blueish colors (180-300)
 	const saturation = 60 + (hash % 20); // 60-80%
@@ -74,7 +79,7 @@ const Canvas: React.FC<CanvasProps> = ({
 				);
 
 				// Use a function to get the current elements to avoid stale closure
-				setLayouts((currentLayouts) => {
+				setLayouts((_currentLayouts) => {
 					// Get the current elements array from ref
 					const currentElements = elementsRef.current;
 					console.log(
@@ -84,7 +89,7 @@ const Canvas: React.FC<CanvasProps> = ({
 
 					const newLayouts = newWorkerLayouts
 						.map((layout) => {
-							let element = currentElements.find(
+							const element = currentElements.find(
 								(e) => e.id === layout.element.id,
 							);
 							if (!element) {
@@ -178,7 +183,7 @@ const Canvas: React.FC<CanvasProps> = ({
 	}, []);
 
 	const handleDrag = useCallback(
-		(event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
+		(_event: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) => {
 			const canvasRect = canvasRef.current?.getBoundingClientRect();
 			if (!canvasRect || !draggedElement) return;
 
@@ -272,14 +277,21 @@ const Canvas: React.FC<CanvasProps> = ({
 		[elements, onElementsChange],
 	);
 
+	const handleRemoveElement = useCallback(
+		(elementId: string) => {
+			const newElements = elements.filter((el) => el.id !== elementId);
+			onElementsChange(newElements);
+		},
+		[elements, onElementsChange],
+	);
+
 	return (
 		<div className={cn("flex w-full h-full p-2")}>
 			<div className={cn("relative w-full h-full rounded-md overflow-hidden")}>
 				<div
 					ref={canvasRef}
-					className={cn(
-						"absolute top-0 left-0 w-full h-full overflow-hidden m-0 p-0",
-					)}
+					className={cn("absolute left-0 w-full overflow-hidden m-0 p-0")}
+					style={{ top: "30px", height: "calc(100% - 30px)" }}
 				>
 					{layouts.map((layout) => {
 						if ("rectangle" in layout.element.kind) {
@@ -290,7 +302,7 @@ const Canvas: React.FC<CanvasProps> = ({
 									onDragStart={handleDragStart}
 									onDragEnd={handleDragEnd}
 									onDrag={
-										layout.element === draggedElement ? handleDrag : undefined
+										layout.element === draggedElement ? handleDrag : () => {}
 									}
 									onRectangleUpdate={handleRectangleUpdate}
 									isDragTarget={layout.element === dragTarget}
@@ -305,7 +317,7 @@ const Canvas: React.FC<CanvasProps> = ({
 									onDragStart={handleDragStart}
 									onDragEnd={handleDragEnd}
 									onDrag={
-										layout.element === draggedElement ? handleDrag : undefined
+										layout.element === draggedElement ? handleDrag : () => {}
 									}
 									onTerminalUpdate={handleTerminalUpdate}
 									isDragTarget={layout.element === dragTarget}
@@ -321,7 +333,7 @@ const Canvas: React.FC<CanvasProps> = ({
 									onDragStart={handleDragStart}
 									onDragEnd={handleDragEnd}
 									onDrag={
-										layout.element === draggedElement ? handleDrag : undefined
+										layout.element === draggedElement ? handleDrag : () => {}
 									}
 									isDragTarget={layout.element === dragTarget}
 									isDragging={layout.element === draggedElement}
@@ -339,9 +351,10 @@ const Canvas: React.FC<CanvasProps> = ({
 									onDragStart={handleDragStart}
 									onDragEnd={handleDragEnd}
 									onDrag={
-										layout.element === draggedElement ? handleDrag : undefined
+										layout.element === draggedElement ? handleDrag : () => {}
 									}
 									onFileTreeUpdate={handleFileTreeUpdate}
+									onRemoveElement={handleRemoveElement}
 									isDragTarget={layout.element === dragTarget}
 									isDragging={layout.element === draggedElement}
 								/>

--- a/frontend/tauri-app/src/canvas/Canvas.tsx
+++ b/frontend/tauri-app/src/canvas/Canvas.tsx
@@ -305,6 +305,7 @@ const Canvas: React.FC<CanvasProps> = ({
 										layout.element === draggedElement ? handleDrag : () => {}
 									}
 									onRectangleUpdate={handleRectangleUpdate}
+									onRemoveElement={handleRemoveElement}
 									isDragTarget={layout.element === dragTarget}
 									isDragging={layout.element === draggedElement}
 								/>
@@ -320,6 +321,7 @@ const Canvas: React.FC<CanvasProps> = ({
 										layout.element === draggedElement ? handleDrag : () => {}
 									}
 									onTerminalUpdate={handleTerminalUpdate}
+									onRemoveElement={handleRemoveElement}
 									isDragTarget={layout.element === dragTarget}
 									isDragging={layout.element === draggedElement}
 								/>

--- a/frontend/tauri-app/src/canvas/FileTreeCanvas.ts
+++ b/frontend/tauri-app/src/canvas/FileTreeCanvas.ts
@@ -1,0 +1,38 @@
+import { CanvasElement, ElementTargets } from "./types";
+
+export class FileTreeCanvas {
+	private _targets: ElementTargets;
+	private _rootPath: string;
+
+	constructor(targets: ElementTargets, rootPath: string = "/") {
+		this._targets = targets;
+		this._rootPath = rootPath;
+	}
+
+	targets(): ElementTargets {
+		return this._targets;
+	}
+
+	updateTargets(newTargets: Partial<ElementTargets>): void {
+		this._targets = { ...this._targets, ...newTargets };
+	}
+
+	get rootPath(): string {
+		return this._rootPath;
+	}
+
+	setRootPath(path: string): void {
+		this._rootPath = path;
+	}
+
+	static canvasElement(
+		targets: ElementTargets,
+		rootPath?: string,
+		weight: number = 1,
+	): CanvasElement {
+		return new CanvasElement(
+			{ fileTree: new FileTreeCanvas(targets, rootPath) },
+			weight,
+		);
+	}
+}

--- a/frontend/tauri-app/src/canvas/FileTreeOnCanvas.tsx
+++ b/frontend/tauri-app/src/canvas/FileTreeOnCanvas.tsx
@@ -1,0 +1,154 @@
+import React, { useState } from "react";
+import { motion, PanInfo } from "framer-motion";
+import { CanvasElement, ElementLayout, ElementTargets } from "./types";
+import { FileTreeCanvas } from "./FileTreeCanvas";
+import { cn } from "../utils";
+import { useStore } from "../state";
+import { FileTree } from "../components/FileTree";
+
+interface FileTreeOnCanvasProps {
+	layout: ElementLayout;
+	onDragStart: (element: CanvasElement) => void;
+	onDragEnd: (element: CanvasElement) => void;
+	onDrag: (
+		event: MouseEvent | TouchEvent | PointerEvent,
+		info: PanInfo,
+	) => void;
+	onFileTreeUpdate: (
+		element: FileTreeCanvas,
+		newTargets: ElementTargets,
+	) => void;
+	isDragTarget: boolean;
+	isDragging: boolean;
+}
+
+const FileTreeOnCanvas: React.FC<FileTreeOnCanvasProps> = ({
+	layout,
+	onDragStart: propOnDragStart,
+	onDragEnd: propOnDragEnd,
+	onDrag: propOnDrag,
+	onFileTreeUpdate,
+	isDragTarget,
+	isDragging,
+}) => {
+	const { cell, element } = layout;
+	const [isHovered, setIsHovered] = useState(false);
+	const [dragging, setDragging] = useState(false);
+	const [rootPath, setRootPath] = useState(
+		"fileTree" in element.kind ? element.kind.fileTree.rootPath : "/Users/ale",
+	);
+	const { theme } = useStore();
+
+	const handleDragStartInternal = () => {
+		propOnDragStart(element);
+	};
+
+	const handleDragEndInternal = () => {
+		propOnDragEnd(element);
+	};
+
+	const handleFileSelect = (path: string) => {
+		// TODO: Implement file opening logic
+	};
+
+	const changeDirectory = () => {
+		const newPath = prompt("Enter directory path:", rootPath);
+		if (newPath && "fileTree" in element.kind) {
+			element.kind.fileTree.setRootPath(newPath);
+			setRootPath(newPath);
+		}
+	};
+
+	return (
+		<motion.div
+			className={cn(
+				`absolute cursor-move select-none`,
+				isDragging ? "z-30" : "z-10",
+			)}
+			initial={{
+				x: cell.x,
+				y: cell.y,
+				width: cell.width,
+				height: cell.height,
+			}}
+			animate={
+				!dragging
+					? {
+							x: cell.x,
+							y: cell.y,
+							width: cell.width,
+							height: cell.height,
+						}
+					: undefined
+			}
+			transition={{
+				type: "tween",
+				duration: 0.2,
+			}}
+			layout
+			drag
+			dragMomentum={false}
+			onMouseDown={() => {
+				if (!dragging) {
+					setDragging(true);
+				}
+			}}
+			onDragStart={() => {
+				setDragging(true);
+				handleDragStartInternal();
+			}}
+			onDragEnd={() => {
+				setDragging(false);
+				handleDragEndInternal();
+			}}
+			onDrag={(event, info) => {
+				if (typeof propOnDrag === "function") {
+					propOnDrag(event, info);
+				}
+			}}
+			onMouseEnter={() => setIsHovered(true)}
+			onMouseLeave={() => {
+				setIsHovered(false);
+			}}
+		>
+			<div
+				className={cn(
+					"w-full h-full rounded-md backdrop-blur-md bg-[var(--bg-400)]/90 border border-[var(--fg-600)]/20 overflow-hidden flex flex-col",
+					`theme-${theme}`,
+				)}
+			>
+				{/* Header */}
+				<div className="flex items-center justify-between p-2 border-b border-[var(--fg-600)]/20 bg-[var(--bg-500)]/50">
+					<span className="text-xs font-medium text-[var(--fg-200)]">
+						📁 Files
+					</span>
+					<button
+						onClick={(e) => {
+							e.stopPropagation();
+							changeDirectory();
+						}}
+						className="text-xs px-1 py-0.5 bg-[var(--bg-600)] hover:bg-[var(--bg-700)] rounded transition-colors text-[var(--fg-300)]"
+					>
+						📂
+					</button>
+				</div>
+
+				{/* File Tree Content */}
+				<div className="flex-1 overflow-auto p-1">
+					<div className="text-xs text-[var(--fg-400)] mb-1 px-1 truncate">
+						{rootPath}
+					</div>
+					<div
+						className="text-xs"
+						onClick={(e) => e.stopPropagation()}
+						onMouseDown={(e) => e.stopPropagation()}
+					>
+						<FileTree rootPath={rootPath} onFileSelect={handleFileSelect} />
+					</div>
+				</div>
+			</div>
+		</motion.div>
+	);
+};
+
+export default FileTreeOnCanvas;

--- a/frontend/tauri-app/src/canvas/FileTreeOnCanvas.tsx
+++ b/frontend/tauri-app/src/canvas/FileTreeOnCanvas.tsx
@@ -1,10 +1,11 @@
-import React, { useState } from "react";
-import { motion, PanInfo } from "framer-motion";
-import { CanvasElement, ElementLayout, ElementTargets } from "./types";
-import { FileTreeCanvas } from "./FileTreeCanvas";
-import { cn } from "../utils";
-import { useStore } from "../state";
+import { motion, type PanInfo } from "framer-motion";
+import type React from "react";
+import { useState } from "react";
 import { FileTree } from "../components/FileTree";
+import { useStore } from "../state";
+import { cn } from "../utils";
+import type { FileTreeCanvas } from "./FileTreeCanvas";
+import type { CanvasElement, ElementLayout, ElementTargets } from "./types";
 
 interface FileTreeOnCanvasProps {
 	layout: ElementLayout;
@@ -18,6 +19,7 @@ interface FileTreeOnCanvasProps {
 		element: FileTreeCanvas,
 		newTargets: ElementTargets,
 	) => void;
+	onRemoveElement: (elementId: string) => void;
 	isDragTarget: boolean;
 	isDragging: boolean;
 }
@@ -28,6 +30,7 @@ const FileTreeOnCanvas: React.FC<FileTreeOnCanvasProps> = ({
 	onDragEnd: propOnDragEnd,
 	onDrag: propOnDrag,
 	onFileTreeUpdate,
+	onRemoveElement,
 	isDragTarget,
 	isDragging,
 }) => {
@@ -119,17 +122,17 @@ const FileTreeOnCanvas: React.FC<FileTreeOnCanvasProps> = ({
 			>
 				{/* Header */}
 				<div className="flex items-center justify-between p-2 border-b border-[var(--fg-600)]/20 bg-[var(--bg-500)]/50">
-					<span className="text-xs font-medium text-[var(--fg-200)]">
-						📁 Files
-					</span>
+					<span className="text-xs font-medium">📁 Files</span>
 					<button
+						type="button"
 						onClick={(e) => {
+							e.preventDefault();
 							e.stopPropagation();
-							changeDirectory();
+							onRemoveElement(element.id);
 						}}
-						className="text-xs px-1 py-0.5 bg-[var(--bg-600)] hover:bg-[var(--bg-700)] rounded transition-colors text-[var(--fg-300)]"
+						className="text-xs w-6 h-6 bg-[var(--fg-800)] hover:bg-[var(--fg-700)] rounded transition-colors text-[var(--bg-white)] flex items-center justify-center"
 					>
-						📂
+						×
 					</button>
 				</div>
 
@@ -138,11 +141,7 @@ const FileTreeOnCanvas: React.FC<FileTreeOnCanvasProps> = ({
 					<div className="text-xs text-[var(--fg-400)] mb-1 px-1 truncate">
 						{rootPath}
 					</div>
-					<div
-						className="text-xs"
-						onClick={(e) => e.stopPropagation()}
-						onMouseDown={(e) => e.stopPropagation()}
-					>
+					<div className="text-xs">
 						<FileTree rootPath={rootPath} onFileSelect={handleFileSelect} />
 					</div>
 				</div>

--- a/frontend/tauri-app/src/canvas/RectangleOnCanvas.tsx
+++ b/frontend/tauri-app/src/canvas/RectangleOnCanvas.tsx
@@ -1,11 +1,11 @@
-import React, { useContext, useState } from "react";
-import { motion, PanInfo } from "framer-motion";
-import { CanvasElement, ElementLayout, ElementTargets } from "./types";
-import { Rectangle } from "./Rectangle";
-import ElementOverlay from "./ElementOverlay";
-import { cn } from "../utils";
+import { motion, type PanInfo } from "framer-motion";
+import type React from "react";
+import { useState } from "react";
 import Logo from "../components/Logo";
 import { useStore } from "../state";
+import { cn } from "../utils";
+import type { Rectangle } from "./Rectangle";
+import type { CanvasElement, ElementLayout, ElementTargets } from "./types";
 
 interface RectangleOnCanvasProps {
 	layout: ElementLayout;
@@ -16,6 +16,7 @@ interface RectangleOnCanvasProps {
 		info: PanInfo,
 	) => void;
 	onRectangleUpdate: (element: Rectangle, newTargets: ElementTargets) => void;
+	onRemoveElement: (elementId: string) => void;
 	isDragTarget: boolean;
 	isDragging: boolean;
 }
@@ -26,6 +27,7 @@ const RectangleOnCanvas: React.FC<RectangleOnCanvasProps> = ({
 	onDragEnd: propOnDragEnd,
 	onDrag: propOnDrag,
 	onRectangleUpdate,
+	onRemoveElement,
 	isDragTarget,
 	isDragging,
 }) => {
@@ -126,31 +128,36 @@ const RectangleOnCanvas: React.FC<RectangleOnCanvasProps> = ({
 		>
 			<div
 				className={cn(
-					"w-full h-full flex items-center justify-center rounded-md backdrop-blur-md bg-[var(--bg-200)]/10",
+					"w-full h-full rounded-md backdrop-blur-md bg-[var(--bg-400)]/90 border border-[var(--fg-600)]/20 overflow-hidden flex flex-col",
 				)}
 			>
-				{/* {(isHovered || showOverlay) && !showOverlay && (
-        <button
-          className={cn("absolute top-1 right-1 w-6 h-6 bg-[var(--fg-800)] text-[var(--bg-white)] rounded text-xs hover:bg-[var(--fg-700)] z-10 border border-[var(--fg-600)]")}
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            console.log('Gear button clicked for', element.id);
-            setShowOverlay(true);
-          }}
-        >
-          ⚙
-        </button>
-      )} */}
+				{/* Header */}
+				<div className="flex items-center justify-between p-2 border-b border-[var(--fg-600)]/20 bg-[var(--bg-500)]/50">
+					<span className="text-xs font-medium">✨ Ariana</span>
+					<button
+						type="button"
+						onClick={(e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							onRemoveElement(element.id);
+						}}
+						className="text-xs w-6 h-6 bg-[var(--fg-800)] hover:bg-[var(--fg-700)] rounded transition-colors text-[var(--bg-white)] flex items-center justify-center"
+					>
+						×
+					</button>
+				</div>
 
-				<div className={cn("select-none")} style={{ width: cell.width / 4 }}>
-					<Logo
-						className={cn(
-							isLightTheme
-								? "text-[var(--fg-800-30)]"
-								: "text-[var(--fg-100-30)]",
-						)}
-					/>
+				{/* Logo Content */}
+				<div className={cn("flex-1 flex items-center justify-center")}>
+					<div className={cn("select-none")} style={{ width: cell.width / 4 }}>
+						<Logo
+							className={cn(
+								isLightTheme
+									? "text-[var(--fg-800-30)]"
+									: "text-[var(--fg-100-30)]",
+							)}
+						/>
+					</div>
 				</div>
 
 				{/* {showOverlay && element instanceof Rectangle && (

--- a/frontend/tauri-app/src/canvas/types.ts
+++ b/frontend/tauri-app/src/canvas/types.ts
@@ -1,6 +1,7 @@
-import { Rectangle } from "./Rectangle";
-import { Terminal } from "./Terminal";
-import { CustomTerminal } from "./CustomTerminal";
+import type { CustomTerminal } from "./CustomTerminal";
+import type { FileTreeCanvas } from "./FileTreeCanvas";
+import type { Rectangle } from "./Rectangle";
+import type { Terminal } from "./Terminal";
 
 export type SizeTarget = "small" | "medium" | "large";
 export type AreaTarget =
@@ -38,11 +39,13 @@ export interface ElementLayout {
 export type CanvasElementKind =
 	| RectangleKind
 	| TerminalKind
-	| CustomTerminalKind;
+	| CustomTerminalKind
+	| FileTreeKind;
 
 export type RectangleKind = { rectangle: Rectangle };
 export type TerminalKind = { terminal: Terminal };
 export type CustomTerminalKind = { customTerminal: CustomTerminal };
+export type FileTreeKind = { fileTree: FileTreeCanvas };
 
 export class CanvasElement {
 	public weight: number;
@@ -62,6 +65,8 @@ export class CanvasElement {
 			return this.kind.terminal.targets();
 		} else if ("customTerminal" in this.kind) {
 			return this.kind.customTerminal.targets();
+		} else if ("fileTree" in this.kind) {
+			return this.kind.fileTree.targets();
 		}
 		throw new Error("Invalid kind");
 	}

--- a/frontend/tauri-app/src/components/FileTree.tsx
+++ b/frontend/tauri-app/src/components/FileTree.tsx
@@ -115,7 +115,7 @@ export const FileTree: React.FC<FileTreeProps> = ({
 									path: node.path,
 								});
 								return { ...node, children };
-							} catch (err) {
+							} catch {
 								return node;
 							}
 						} else if (node.children) {

--- a/frontend/tauri-app/src/components/FileTree.tsx
+++ b/frontend/tauri-app/src/components/FileTree.tsx
@@ -1,4 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
+import { getIcon } from "material-file-icons";
 import type React from "react";
 import { useEffect, useState } from "react";
 
@@ -49,9 +50,23 @@ const FileTreeItem: React.FC<{
 						{isExpanded ? "▼" : "▶"}
 					</span>
 				)}
-				<span>
-					{node.isDirectory ? "📁" : "📄"} {node.name}
-				</span>
+				{node.isDirectory ? (
+					<span>📁</span>
+				) : (
+					<span
+						// biome-ignore lint/security/noDangerouslySetInnerHtml: ive never done this but its working...
+						dangerouslySetInnerHTML={{
+							__html: getIcon(node.name).svg,
+						}}
+						style={{
+							width: "16px",
+							height: "16px",
+							display: "inline-block",
+							verticalAlign: "middle",
+						}}
+					/>
+				)}
+				<span>{node.name}</span>
 			</div>
 			{isExpanded && node.children && (
 				<div>

--- a/frontend/tauri-app/src/components/FileTree.tsx
+++ b/frontend/tauri-app/src/components/FileTree.tsx
@@ -1,0 +1,160 @@
+import { invoke } from "@tauri-apps/api/core";
+import type React from "react";
+import { useEffect, useState } from "react";
+
+interface FileNode {
+	name: string;
+	path: string;
+	isDirectory: boolean;
+	children?: FileNode[] | null;
+	extension?: string | null;
+}
+
+interface FileTreeProps {
+	rootPath: string;
+	onFileSelect?: (path: string) => void;
+}
+
+const FileTreeItem: React.FC<{
+	node: FileNode;
+	depth: number;
+	onFileSelect?: (path: string) => void;
+	onToggle?: (path: string) => void;
+	isExpanded?: boolean;
+}> = ({ node, depth, onFileSelect, onToggle, isExpanded }) => {
+	const handleClick = () => {
+		if (node.isDirectory) {
+			onToggle?.(node.path);
+		} else {
+			onFileSelect?.(node.path);
+		}
+	};
+
+	return (
+		<div>
+			<div
+				onClick={handleClick}
+				style={{
+					paddingLeft: `${depth * 16}px`,
+					padding: "4px 8px",
+					cursor: "pointer",
+					display: "flex",
+					alignItems: "center",
+					gap: "4px",
+				}}
+				className="file-tree-item"
+			>
+				{node.isDirectory && (
+					<span style={{ width: "12px", display: "inline-block" }}>
+						{isExpanded ? "▼" : "▶"}
+					</span>
+				)}
+				<span>
+					{node.isDirectory ? "📁" : "📄"} {node.name}
+				</span>
+			</div>
+			{isExpanded && node.children && (
+				<div>
+					{node.children.map((child, index) => (
+						<FileTreeItem
+							key={`${child.path}-${index}`}
+							node={child}
+							depth={depth + 1}
+							onFileSelect={onFileSelect}
+							onToggle={onToggle}
+							isExpanded={false}
+						/>
+					))}
+				</div>
+			)}
+		</div>
+	);
+};
+
+export const FileTree: React.FC<FileTreeProps> = ({
+	rootPath,
+	onFileSelect,
+}) => {
+	const [files, setFiles] = useState<FileNode[]>([]);
+	const [expandedPaths, setExpandedPaths] = useState<Set<string>>(new Set());
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+
+	useEffect(() => {
+		loadDirectory(rootPath);
+	}, [rootPath]);
+
+	const loadDirectory = async (path: string) => {
+		try {
+			setLoading(true);
+			setError(null);
+			const result = await invoke<FileNode[]>("get_file_tree", { path });
+			setFiles(result);
+		} catch (err) {
+			setError(err instanceof Error ? err.message : "Failed to load directory");
+		} finally {
+			setLoading(false);
+		}
+	};
+
+	const handleToggle = async (path: string) => {
+		const newExpanded = new Set(expandedPaths);
+		if (newExpanded.has(path)) {
+			newExpanded.delete(path);
+		} else {
+			newExpanded.add(path);
+
+			const updateNodeChildren = async (
+				nodes: FileNode[],
+			): Promise<FileNode[]> => {
+				return Promise.all(
+					nodes.map(async (node) => {
+						if (node.path === path && node.isDirectory && !node.children) {
+							try {
+								const children = await invoke<FileNode[]>("get_file_tree", {
+									path: node.path,
+								});
+								return { ...node, children };
+							} catch (err) {
+								return node;
+							}
+						} else if (node.children) {
+							return {
+								...node,
+								children: await updateNodeChildren(node.children),
+							};
+						}
+						return node;
+					}),
+				);
+			};
+
+			const updatedFiles = await updateNodeChildren(files);
+			setFiles(updatedFiles);
+		}
+		setExpandedPaths(newExpanded);
+	};
+
+	if (loading) {
+		return <div style={{ padding: "16px", color: "white" }}>Loading...</div>;
+	}
+
+	if (error) {
+		return <div style={{ padding: "16px", color: "red" }}>Error: {error}</div>;
+	}
+
+	return (
+		<div style={{ fontFamily: "monospace", fontSize: "14px" }}>
+			{files.map((file, index) => (
+				<FileTreeItem
+					key={`${file.path}-${index}`}
+					node={file}
+					depth={0}
+					onFileSelect={onFileSelect}
+					onToggle={handleToggle}
+					isExpanded={expandedPaths.has(file.path)}
+				/>
+			))}
+		</div>
+	);
+};


### PR DESCRIPTION
- implemented file tree panel with resizable support on canvas
- added rust backend for file tree traversal with gitignore handling
- integrated material design icons for different file types
- added safe area at top of window to prevent panel buttons interfering with window controls
- added close/open buttons for terminal in the main window panel
- added x button to ariana panel for closing functionality