### PR TITLE
Remove unused STALE_PR_CUTOFF_DAYS constant

### DIFF
--- a/backend/src/services/agent.service.ts
+++ b/backend/src/services/agent.service.ts
@@ -67,7 +67,6 @@ export class AgentService {
   private readonly activeChains = new Map<string, ChainState>(); // key = "agentId:data" or "agentId:state"
   private readonly sharedMsgCount = new Map<string, number>(); // written by data chain, read by state chain
   private readonly recentTimings: ChainTiming[] = []; // ring buffer for benchmark logging
-  private readonly STALE_PR_CUTOFF_DAYS = 7;
 
   constructor(
     private repositories: RepositoryContainer,


### PR DESCRIPTION
## Summary
- Removed unused `STALE_PR_CUTOFF_DAYS` constant from `backend/src/services/agent.service.ts` (~line 70)
- The constant was defined but never referenced anywhere in the codebase

## Test plan
- No functional changes; purely dead code removal
