### PR TITLE
Remove duplicate killRunningEventsForAgent call in archiveAgent()

### DIFF
--- a/backend/src/services/agent.service.ts
+++ b/backend/src/services/agent.service.ts
@@ -272,13 +272,6 @@ export class AgentService {
       let stateUpdateSuccess = false;
       let machineReleaseSuccess = false;
 
-      // Kill zombie running automation events (machine is going away)
-      try {
-        await this.repositories.automationEvents.killRunningEventsForAgent(agentId);
-      } catch (error) {
-        logger.warn`Agent ${agentId} - Failed to kill running automation events: ${error}`;
-      }
-
       // Step 1: Update agent state to ARCHIVED (we're already in ARCHIVING)
       try {
         await this.repositories.agents.updateAgentFields(agentId, {


### PR DESCRIPTION
## Summary
- Removed a duplicate `killRunningEventsForAgent` call in `archiveAgent()` in `backend/src/services/agent.service.ts`
- The same call appeared twice (lines ~266 and ~277) with identical logic and error handling
- Kept the first call (before the per-step state update block); removed the redundant second one

## Test plan
- [ ] Verify `archiveAgent()` still kills running automation events before releasing the machine
- [ ] Confirm no regression in agent archival flow
