### PR TITLE
refactor: extract unwrapApiResponse utility for fetch-response unwrap pattern

### DIFF
--- a/dashboard/src/components/CohortAnalysis.tsx
+++ b/dashboard/src/components/CohortAnalysis.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
+import { unwrapApiResponse } from '@/lib/api'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
@@ -98,30 +99,20 @@ export function CohortAnalysis({ excludeUsers = '' }: CohortAnalysisProps) {
         fetch(`${apiUrl}/api/admin/analytics/cohorts/success?period=${period}${excludeParam}`, { headers }),
       ])
 
-      if (activationRes.ok) {
-        const data = await activationRes.json()
-        if (data.success) setActivationData(data.data)
-      }
+      const activation = await unwrapApiResponse<ActivationRateData[]>(activationRes)
+      if (activation) setActivationData(activation)
 
-      if (engagementRes.ok) {
-        const data = await engagementRes.json()
-        if (data.success) setEngagementData(data.data)
-      }
+      const engagement = await unwrapApiResponse<EngagementProgressionData[]>(engagementRes)
+      if (engagement) setEngagementData(engagement)
 
-      if (timeToActionRes.ok) {
-        const data = await timeToActionRes.json()
-        if (data.success) setTimeToActionData(data.data)
-      }
+      const timeToAction = await unwrapApiResponse<TimeToFirstActionData[]>(timeToActionRes)
+      if (timeToAction) setTimeToActionData(timeToAction)
 
-      if (retentionRes.ok) {
-        const data = await retentionRes.json()
-        if (data.success) setRetentionData(data.data)
-      }
+      const retention = await unwrapApiResponse<RetentionByWeekData[]>(retentionRes)
+      if (retention) setRetentionData(retention)
 
-      if (successRes.ok) {
-        const data = await successRes.json()
-        if (data.success) setSuccessData(data.data)
-      }
+      const success = await unwrapApiResponse<SuccessRateByCohortData[]>(successRes)
+      if (success) setSuccessData(success)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to fetch cohort data')
     } finally {

--- a/dashboard/src/lib/api.ts
+++ b/dashboard/src/lib/api.ts
@@ -1,0 +1,10 @@
+/**
+ * Unwraps a standard API response of the shape `{ success: boolean, data: T }`.
+ * Returns `data.data` when the response is OK and `data.success` is true,
+ * otherwise returns `undefined`.
+ */
+export async function unwrapApiResponse<T>(res: Response): Promise<T | undefined> {
+  if (!res.ok) return undefined
+  const data = await res.json()
+  return data.success ? (data.data as T) : undefined
+}

--- a/dashboard/src/pages/Dashboard.tsx
+++ b/dashboard/src/pages/Dashboard.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react'
 import { useAuth } from '@/contexts/AuthContext'
+import { unwrapApiResponse } from '@/lib/api'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts'
@@ -138,20 +139,14 @@ export function Dashboard() {
         }),
       ])
 
-      if (distributionRes.ok) {
-        const data = await distributionRes.json()
-        if (data.success) setUserDistribution(data.data)
-      }
+      const distribution = await unwrapApiResponse<UserDistributionData[]>(distributionRes)
+      if (distribution) setUserDistribution(distribution)
 
-      if (retentionRes.ok) {
-        const data = await retentionRes.json()
-        if (data.success) setRetentionCohorts(data.data)
-      }
+      const retention = await unwrapApiResponse<RetentionCohortData[]>(retentionRes)
+      if (retention) setRetentionCohorts(retention)
 
-      if (sessionRes.ok) {
-        const data = await sessionRes.json()
-        if (data.success) setSessionDuration(data.data)
-      }
+      const session = await unwrapApiResponse<SessionDurationData[]>(sessionRes)
+      if (session) setSessionDuration(session)
     } catch (err) {
       console.error('Failed to fetch analytics:', err)
     }


### PR DESCRIPTION
## Summary
- Created `dashboard/src/lib/api.ts` with a single `unwrapApiResponse<T>(res: Response): Promise<T | undefined>` helper
- Replaced 3 occurrences in `Dashboard.tsx` and 5 in `CohortAnalysis.tsx` (8 total)
- Each 3-line inline block (`if res.ok → json() → if data.success → setState`) is now one typed call

## Test plan
- [ ] `npx tsc --noEmit` passes with zero errors
- [ ] Analytics data still loads correctly on the dashboard
- [ ] Cohort analysis charts still render with data