### PR TITLE
Update README with full URL for cloud version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We maintain it on a private repo and will occasionally drop progress here. Feel 
 
 ## Try it
 
-A cloud version is hosted there: [ariana.dev](ariana.dev)
+A cloud version is hosted there: [ariana.dev](https://ariana.dev)
 
 You can use it from Desktop, Web and Mobile Web
 


### PR DESCRIPTION
The current one opens ariana.dev as github site route which gives error. Needed full url.